### PR TITLE
Use best practices for determining the size of an array element

### DIFF
--- a/Language/Variables/Utilities/sizeof.adoc
+++ b/Language/Variables/Utilities/sizeof.adoc
@@ -78,7 +78,7 @@ Note that `sizeof` returns the total number of bytes. So for larger variable typ
 
 [source,arduino]
 ----
-for (i = 0; i < (sizeof(myInts)/sizeof(int)); i++) {
+for (i = 0; i < (sizeof(myInts)/sizeof(myInts[0])); i++) {
   // do something with myInts[i]
 }
 ----


### PR DESCRIPTION
The previous code does not automatically adapt to changes in the type of myInts.

Reference: https://github.com/arduino/reference-en/commit/b0791f1b26e33b290b0660f664cf3cae5a350cca